### PR TITLE
Don't sent cque event

### DIFF
--- a/src/ev_mgr.c
+++ b/src/ev_mgr.c
@@ -1213,7 +1213,7 @@ int modules_init(ksnetEvMgrClass *ke) {
     
     // Callback QUEUE
     #if M_ENAMBE_CQUE
-    ke->kq = ksnCQueInit(ke);
+    ke->kq = ksnCQueInit(ke, 0);
     #endif
 
     // Stream module

--- a/src/modules/cque.h
+++ b/src/modules/cque.h
@@ -20,6 +20,7 @@ typedef struct ksnCQueClass {
     void *ke; ///< Pointer to ksnEvMgrClass
     uint32_t id; ///< New callback queue ID
     PblMap *cque_map; ///< Pointer to the callback queue pblMap
+    uint8_t event_f; ///< Send cque event if true
     
 } ksnCQueClass;
 
@@ -52,7 +53,7 @@ typedef struct ksnCQueData {
 extern "C" {
 #endif
 
-ksnCQueClass *ksnCQueInit(void *ke);
+ksnCQueClass *ksnCQueInit(void *ke, uint8_t send_event);
 void ksnCQueDestroy(ksnCQueClass *kq);
 
 int ksnCQueExec(ksnCQueClass *kq, uint32_t id);

--- a/tests/test_cque.c
+++ b/tests/test_cque.c
@@ -39,7 +39,7 @@ void test_4_1() {
     kc_emul();
 
     // Initialize module
-    ksnCQueClass *kq = ksnCQueInit(ke);
+    ksnCQueClass *kq = ksnCQueInit(ke, 1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(kq);
     CU_ASSERT_PTR_NOT_NULL_FATAL(kq->cque_map);
     
@@ -81,7 +81,7 @@ void test_4_2() {
     kc_emul();
 
     // Initialize module
-    ksnCQueClass *kq = ksnCQueInit(ke);
+    ksnCQueClass *kq = ksnCQueInit(ke, 1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(kq);
     CU_ASSERT_PTR_NOT_NULL_FATAL(kq->cque_map);
     
@@ -113,7 +113,7 @@ void test_4_3() {
     kc_emul();
 
     // Initialize module
-    ksnCQueClass *kq = ksnCQueInit(ke);
+    ksnCQueClass *kq = ksnCQueInit(ke, 1);
     CU_ASSERT_PTR_NOT_NULL_FATAL(kq);
     CU_ASSERT_PTR_NOT_NULL_FATAL(kq->cque_map);
     


### PR DESCRIPTION
Parameter send_event added to cque initialize funtion. The cque event 
will be send when the send_event parameter is true. 

The send_event set to false in teonet internal cque.

issue #27
[skip ci]