### PR TITLE
Teonet Metrics module updated

### DIFF
--- a/sh/statsd/mapping.yml
+++ b/sh/statsd/mapping.yml
@@ -2,7 +2,23 @@ mappings:
     # usage: test_api_call.product-api.timer./v1/product
     # 
     # - match: "teonet.*.*.*.*"
-  - match: "teonet\\.([a-zA-Z0-9-]+)\\.([a-zA-Z0-9-]+)\\.([a-zA-Z0-9-]+)\\.([a-zA-Z0-9-]+)"
+  - match: "teonet\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)\\.PT\\.([a-zA-Z0-9-_]+)"
+    match_type: regex
+    name: "teonet_${1}_peer_relay_time"
+    labels:
+      network: "$2"
+      peer: "$3"
+      remote: "$4"
+      type: "$1"
+  - match: "teonet\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)\\.CON\\.([a-zA-Z0-9-_]+)"
+    match_type: regex
+    name: "teonet_${1}_connected"
+    labels:
+      network: "$2"
+      peer: "$3"
+      remote: "$4"
+      type: "$1"
+  - match: "teonet\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)\\.([a-zA-Z0-9-_]+)"
     match_type: regex
     name: "teonet_${1}_${4}"
     labels:

--- a/src/config/conf.c
+++ b/src/config/conf.c
@@ -114,6 +114,9 @@ void set_defaults(ksnet_cfg *ksn_cfg) {
     
     // Syslog priority
     ksn_cfg->log_priority = DEBUG;
+
+    // Send peers metric flag
+    ksn_cfg->statsd_peers_f = 0;
     
     // Terminal
 //    strncpy(ksn_cfg->t_username, "fred", KSN_BUFFER_SM_SIZE/2);
@@ -134,6 +137,7 @@ void read_config(ksnet_cfg *conf, int port_param) {
         strncpy(conf->host_name, host_name, KSN_MAX_HOST_NAME); \
         strncpy(conf->r_host_addr, r_host_addr, KSN_BUFFER_SM_SIZE/2); \
         strncpy(conf->vpn_ip, vpn_ip, KSN_MAX_HOST_NAME); \
+        strncpy(conf->statsd_ip, statsd_ip, KSN_BUFFER_SM_SIZE/2); \
         strncpy(conf->vpn_dev_name, vpn_dev_name, KSN_MAX_HOST_NAME); \
         strncpy(conf->vpn_dev_hwaddr, vpn_dev_hwaddr, KSN_MAX_HOST_NAME); \
         strncpy(conf->l0_tcp_ip_remote, l0_tcp_ip_remote, KSN_BUFFER_SM_SIZE/2); \
@@ -143,6 +147,7 @@ void read_config(ksnet_cfg *conf, int port_param) {
     char *vpn_ip = strdup(conf->vpn_ip);
     char *filter = strdup(conf->filter);
     char *net_key = strdup(conf->net_key);
+    char *statsd_ip = strdup(conf->statsd_ip);
     char *host_name = strdup(conf->host_name);
     char *r_host_addr = strdup(conf->r_host_addr);
     char *vpn_dev_name = strdup(conf->vpn_dev_name);
@@ -204,14 +209,17 @@ void read_config(ksnet_cfg *conf, int port_param) {
 
         #if M_ENAMBE_LOGGING_CLIENT
         CFG_SIMPLE_BOOL("log_disable_f", (cfg_bool_t*)&conf->log_disable_f),
-        CFG_SIMPLE_BOOL("send_all_logs_f", (cfg_bool_t*)&conf->send_all_logs_f),
-        
+        CFG_SIMPLE_BOOL("send_all_logs_f", (cfg_bool_t*)&conf->send_all_logs_f),        
         #endif        
         
         CFG_SIMPLE_INT("log_priority", &conf->log_priority),
         
         CFG_SIMPLE_BOOL("color_output_disable_f", (cfg_bool_t*)&conf->color_output_disable_f),
         CFG_SIMPLE_BOOL("extended_l0_log_f", (cfg_bool_t*)&conf->extended_l0_log_f),
+
+        CFG_SIMPLE_STR("statsd_ip", &statsd_ip),
+        CFG_SIMPLE_INT("statsd_port", &conf->statsd_port),
+        CFG_SIMPLE_BOOL("statsd_peers_f", (cfg_bool_t*)&conf->statsd_peers_f),
 
         CFG_END()
     };

--- a/src/config/conf.h
+++ b/src/config/conf.h
@@ -129,6 +129,7 @@ typedef struct ksnet_cfg {
     // StatsD address
     char statsd_ip[KSN_BUFFER_SM_SIZE/2];
     long statsd_port;
+    int statsd_peers_f;
     
     // Helpers
     int pp;

--- a/src/config/opt.c
+++ b/src/config/opt.c
@@ -89,6 +89,7 @@ char ** ksnet_optRead(int argc, char **argv, ksnet_cfg *conf,
 
         { "statsd_ip",      required_argument, 0, 's' },
         { "statsd_port",    required_argument, 0, 'S' },
+        { "statsd_peers",   no_argument,       &conf->statsd_peers_f, 1 },
 
         { "sig_segv",       no_argument,       &conf->sig_segv_f, 1 },
         { "log_priority",   required_argument, 0, 'L' }, 
@@ -423,6 +424,7 @@ void opt_usage(char *app_name, int app_argc, char** app_argv) {
     "\n"
     "       --statsd_ip          Metric exporter IP address\n"
     "       --statsd_port        Metric exporter Port number\n"
+    "       --statsd_peers       Send preers metrics\n"
     "\n"
     "       --sig_segv           Segmentation fault error processing by library\n"
     "       --log_priority       Syslog priority (Default: 4):\n"

--- a/src/modules/metric.c
+++ b/src/modules/metric.c
@@ -13,6 +13,8 @@
 #include "metric.h"
 #include "ev_mgr.h"
 
+#define MODULE "metrics"
+
 /**
  * Initialize Metrics module
  * 
@@ -24,8 +26,9 @@ teoMetricClass *teoMetricInit(void *kep) {
     if (ke->ksn_cfg.statsd_ip[0] == 0 || ke->ksn_cfg.statsd_port == 0)
         return NULL;
 
-    printf("Send metrics to statsd exporter at address: %s:%ld\n",
-           ke->ksn_cfg.statsd_ip, ke->ksn_cfg.statsd_port);
+    ksn_printf(ke, MODULE, MESSAGE, 
+        "started, and ready to send metrics to statsd exporter at address: %s:%ld\n",
+        ke->ksn_cfg.statsd_ip, ke->ksn_cfg.statsd_port);
 
     teoMetricClass *tm = malloc(sizeof(teoMetricClass));
     tm->ke = ke;
@@ -118,4 +121,7 @@ void metric_teonet_count(teoMetricClass *tm) {
     static uint64_t gauge = 0;
     teoMetricCounter(tm, "total", 1);
     teoMetricGauge(tm, "tick", gauge++);
+
+    ksnetEvMgrClass *ke = (ksnetEvMgrClass *)tm->ke;    
+    if(ke->ksn_cfg.statsd_peers_f) ksnetArpMetrics(ke->kc->ka); // Arp metrics
 }

--- a/src/net_arp.c
+++ b/src/net_arp.c
@@ -358,6 +358,23 @@ ksnet_arp_data_ar *ksnetArpShowData(ksnetArpClass *ka) {
 }
 
 /**
+ * Send arp table metrics
+ */
+void ksnetArpMetrics(ksnetArpClass *ka) {
+
+    #define kev ((ksnetEvMgrClass*)ka->ke)
+    ksnet_arp_data_ar *arp_data_ar = ksnetArpShowData(ka);
+    char met[256];
+    for(int i = 0; i < arp_data_ar->length; i++) {
+        if(arp_data_ar->arp_data[i].data.mode == -1) continue;
+        int val = 1000*arp_data_ar->arp_data[i].data.last_triptime;
+        snprintf(met, 255, "PT.%s", arp_data_ar->arp_data[i].name);
+        teoMetricGauge(kev->tm, met, val);
+    }
+    #undef kev
+}
+
+/**
  * Convert peers data to JSON
  *
  * @param peers_data Pointer to ksnet_arp_data_ar

--- a/src/net_arp.h
+++ b/src/net_arp.h
@@ -93,6 +93,7 @@ size_t ksnetArpShowDataLength(ksnet_arp_data_ar *peers_data);
 char *ksnetArpShowDataJson(ksnet_arp_data_ar *peers_data, size_t *peers_data_json_len);
 char *ksnetArpShowLine(int num, char *name, ksnet_arp_data* data);
 char *ksnetArpShowHeader(int header_f);
+void ksnetArpMetrics(ksnetArpClass *ka);
 
 #ifdef	__cplusplus
 }

--- a/src/net_com.c
+++ b/src/net_com.c
@@ -721,6 +721,11 @@ static int cmd_host_info_answer_cb(ksnCommandClass *kco, ksnCorePacketData *rd) 
             rd->arp->type = strdup(type_str);
             free(type_str);
 
+            // Metrics
+            char *met = ksnet_formatMessage("CON.%s", rd->from);
+            teoMetricGauge(ke->tm, met, 1);
+            free(met);
+
             // Send event callback
             if(ke->event_cb != NULL)
                 ke->event_cb(ke, EV_K_CONNECTED, (void*)rd, sizeof(*rd), NULL);
@@ -1240,6 +1245,11 @@ int cmd_disconnected_cb(ksnCommandClass *kco, ksnCorePacketData *rd) {
     if(rd->data != NULL && ((char*)rd->data)[0]) {
         peer_name = rd->data;
     }
+
+    // Metrics
+    char *met = ksnet_formatMessage("CON.%s", peer_name);
+    teoMetricGauge(ke->tm, met, 0);
+    free(met);
 
     // Check r-host disconnected
     int is_rhost = ke->ksn_cfg.r_host_name[0] && !strcmp(ke->ksn_cfg.r_host_name,rd->from);


### PR DESCRIPTION
Metrics module updated:
- new metrics connected and peer_relay_time added to TMS default metrics
- new teonet CLI parameter "statsd_peers" added (to start send peer_relay_time metrics, by default it does not send)
- all teonet metrics CLI parameters added to configuration file
- some minor patches in Metrics module